### PR TITLE
Fixed #12: sys/time.h is only available on POSIX platforms

### DIFF
--- a/lib/serialib.cpp
+++ b/lib/serialib.cpp
@@ -1002,7 +1002,16 @@ timeOut::timeOut()
 //Initialize the timer
 void timeOut::initTimer()
 {
+#if defined (NO_POSIX_TIME)
+    LARGE_INTEGER tmp;
+    QueryPerformanceFrequency(&tmp);
+    counterFrequency = tmp.QuadPart;
+    // Used to store the previous time (for computing timeout)
+    QueryPerformanceCounter(&tmp);
+    previousTime = tmp.QuadPart;
+#else
     gettimeofday(&previousTime, NULL);
+#endif
 }
 
 /*!
@@ -1013,6 +1022,21 @@ void timeOut::initTimer()
 //Return the elapsed time since initialization
 unsigned long int timeOut::elapsedTime_ms()
 {
+#if defined (NO_POSIX_TIME)
+    // Current time
+    LARGE_INTEGER CurrentTime;
+    // Number of ticks since last call
+    int sec;
+
+    // Get current time
+    QueryPerformanceCounter(&CurrentTime);
+
+    // Compute the number of ticks elapsed since last call
+    sec=CurrentTime.QuadPart-previousTime;
+
+    // Return the elapsed time in milliseconds
+    return sec/(counterFrequency/1000);
+#else
     // Current time
     struct timeval CurrentTime;
     // Number of seconds and microseconds since last call
@@ -1035,8 +1059,5 @@ unsigned long int timeOut::elapsedTime_ms()
 
     // Return the elapsed time in milliseconds
     return sec*1000+usec/1000;
+#endif
 }
-
-
-
-

--- a/lib/serialib.h
+++ b/lib/serialib.h
@@ -19,12 +19,18 @@ This is a licence-free software, it can be used by anyone who try to build a bet
 #ifndef SERIALIB_H
 #define SERIALIB_H
 
+#if defined(__CYGWIN__)
+    // This is Cygwin special case
+    #include <sys/time.h>
+#endif
+
 // Include for windows
 #if defined (_WIN32) || defined (_WIN64)
-#if defined(__CYGWIN__) || defined(__GNUC__)
-    // sys/time.h does not exist on "actual" Windows
+#if defined(__GNUC__)
+    // This is MinGW special case
     #include <sys/time.h>
 #else
+    // sys/time.h does not exist on "actual" Windows
     #define NO_POSIX_TIME
 #endif
     // Accessing to the serial port under Windows
@@ -39,12 +45,12 @@ This is a licence-free software, it can be used by anyone who try to build a bet
     #include <termios.h>
     #include <string.h>
     #include <iostream>
+    #include <sys/time.h>
     // File control definitions
     #include <fcntl.h>
     #include <unistd.h>
     #include <sys/ioctl.h>
 #endif
-
 
 /*! To avoid unused parameters */
 #define UNUSED(x) (void)(x)

--- a/lib/serialib.h
+++ b/lib/serialib.h
@@ -19,12 +19,14 @@ This is a licence-free software, it can be used by anyone who try to build a bet
 #ifndef SERIALIB_H
 #define SERIALIB_H
 
-
-
-// Used for TimeOut operations
-#include <sys/time.h>
 // Include for windows
 #if defined (_WIN32) || defined (_WIN64)
+#if defined(__CYGWIN__) || defined(__GNUC__)
+    // sys/time.h does not exist on "actual" Windows
+    #include <sys/time.h>
+#else
+    #define NO_POSIX_TIME
+#endif
     // Accessing to the serial port under Windows
     #include <windows.h>
 #endif
@@ -245,8 +247,14 @@ public:
     unsigned long int   elapsedTime_ms();
 
 private:
+#if defined (NO_POSIX_TIME)
+    // Used to store the previous time (for computing timeout)
+    LONGLONG       counterFrequency;
+    LONGLONG       previousTime;
+#else
     // Used to store the previous time (for computing timeout)
     struct timeval      previousTime;
+#endif
 };
 
 #endif // serialib_H


### PR DESCRIPTION
This PR fixes Issue #12  by either including sys/time.h (on POSIX platforms including Cygwin & MinGW), or by relying on a Win32 API equivalent.