### PR TITLE
Initialise handles at construction and use it for device opening state

### DIFF
--- a/lib/serialib.cpp
+++ b/lib/serialib.cpp
@@ -317,9 +317,11 @@ void serialib::closeDevice()
 {
 #if defined (_WIN32) || defined( _WIN64)
     CloseHandle(hSerial);
+    hSerial = INVALID_HANDLE_VALUE;
 #endif
 #if defined (__linux__) || defined(__APPLE__)
     close (fd);
+    fd = -1;
 #endif
 }
 

--- a/lib/serialib.cpp
+++ b/lib/serialib.cpp
@@ -32,6 +32,10 @@ serialib::serialib()
     // Set default value for RTS and DTR (Windows only)
     currentStateRTS=true;
     currentStateDTR=true;
+    hSerial = INVALID_HANDLE_VALUE;
+#endif
+#if defined (__linux__) || defined(__APPLE__)
+    fd = -1;
 #endif
 }
 
@@ -296,6 +300,15 @@ char serialib::openDevice(const char *Device, const unsigned int Bauds,
 
 }
 
+bool serialib::isDeviceOpen()
+{
+#if defined (_WIN32) || defined( _WIN64)
+    return hSerial != INVALID_HANDLE_VALUE;
+#endif
+#if defined (__linux__) || defined(__APPLE__)
+    return fd >= 0;
+#endif
+}
 
 /*!
      \brief Close the connection with the current device

--- a/lib/serialib.h
+++ b/lib/serialib.h
@@ -116,6 +116,9 @@ public:
                     SerialParity Parity = SERIAL_PARITY_NONE,
                     SerialStopBits Stopbits = SERIAL_STOPBITS_1);
 
+    // Check device opening state
+    bool isDeviceOpen();
+
     // Close the current device
     void    closeDevice();
 


### PR DESCRIPTION
This change makes so either handles are invalid due to an unconnected device, or valid after a valid connection - no more random values after construction.