### PR TITLE
Alternate signature for writeBytes that lets you know how many bytes were written

### DIFF
--- a/lib/serialib.cpp
+++ b/lib/serialib.cpp
@@ -405,13 +405,11 @@ char serialib::writeString(const char *receivedString)
      \return 1 success
      \return -1 error while writting data
   */
-char serialib::writeBytes(const void *Buffer, const unsigned int NbBytes)
+char serialib::writeBytes(const void *Buffer, const unsigned int NbBytes, unsigned int *NbBytesWritten)
 {
 #if defined (_WIN32) || defined( _WIN64)
-    // Number of bytes written
-    DWORD dwBytesWritten;
     // Write data
-    if(!WriteFile(hSerial, Buffer, NbBytes, &dwBytesWritten, NULL))
+    if(!WriteFile(hSerial, Buffer, NbBytes, NbBytesWritten, NULL))
         // Error while writing, return -1
         return -1;
     // Write operation successfull
@@ -419,13 +417,18 @@ char serialib::writeBytes(const void *Buffer, const unsigned int NbBytes)
 #endif
 #if defined (__linux__) || defined(__APPLE__)
     // Write data
-    if (write (fd,Buffer,NbBytes)!=(ssize_t)NbBytes) return -1;
+    *NbBytesWritten = write (fd,Buffer,NbBytes);
+    if (*NbBytesWritten !=(ssize_t)NbBytes) return -1;
     // Write operation successfull
     return 1;
 #endif
 }
 
-
+char serialib::writeBytes(const void *Buffer, const unsigned int NbBytes)
+{
+    unsigned int NbBytesWritten;
+    writeBytes(Buffer, NbBytes, &NbBytesWritten)
+}
 
 /*!
      \brief Wait for a byte from the serial device and return the data read

--- a/lib/serialib.cpp
+++ b/lib/serialib.cpp
@@ -482,7 +482,7 @@ int serialib::writeBytes(const void *Buffer, const unsigned int NbBytes, unsigne
 int serialib::writeBytes(const void *Buffer, const unsigned int NbBytes)
 {
     unsigned int NbBytesWritten;
-    return writeBytes(Buffer, NbBytes, &NbBytesWritten)
+    return writeBytes(Buffer, NbBytes, &NbBytesWritten);
 }
 
 /*!

--- a/lib/serialib.h
+++ b/lib/serialib.h
@@ -158,6 +158,7 @@ public:
 
 
     // Write an array of bytes
+    int     writeBytes(const void *Buffer, const unsigned int NbBytes, unsigned int *NbBytesWritten);
     int     writeBytes  (const void *Buffer, const unsigned int NbBytes);
 
     // Read an array of byte (with timeout)


### PR DESCRIPTION
I ran into an issue where the serial driver on OSX was limited to a 1024-byte write buffer, after which it would truncate the message. To handle this properly, I needed to access the number of bytes written as reported by the write calls used by writeBytes.

This alternate signature takes an additional argument, a pointer to an unsigned integer. Null should not be provided to this argument.

The old signature is used for a wrapper that provides a throwaway stack variable to receive the number of bytes written.